### PR TITLE
REFACTOR: set correct Chinese fonts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true   
@@ -20,10 +20,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 8
-
-      - name: Install Chinese fonts
-        run: |
-            sudo apt-get install -y fonts-noto-cjk
             
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
@@ -41,7 +37,7 @@ jobs:
           node script/build.cjs
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public

--- a/lecture/Lecture1/Lecture0.md
+++ b/lecture/Lecture1/Lecture0.md
@@ -11,6 +11,10 @@ drawings:
 transition: slide-left
 mdc: true
 level: 1
+fonts:
+  sans: Noto Sans SC
+  serif: Noto Serif SC
+  mono: JetBrains Mono
 ---
 
 # Lecture 0

--- a/lecture/Lecture1/Lecture1.md
+++ b/lecture/Lecture1/Lecture1.md
@@ -6,6 +6,10 @@ transition: slide-left
 level: 1
 layout: cover
 download: true
+fonts:
+  sans: Noto Sans SC
+  serif: Noto Serif SC
+  mono: JetBrains Mono
 ---
 
 

--- a/lecture/Lecture2/Lecture2.md
+++ b/lecture/Lecture2/Lecture2.md
@@ -11,6 +11,10 @@ drawings:
 transition: slide-left
 mdc: true
 level: 1
+fonts:
+  sans: Noto Sans SC
+  serif: Noto Serif SC
+  mono: JetBrains Mono
 ---
 
 # Lecture 2

--- a/lecture/Lecture3/Lecture3.md
+++ b/lecture/Lecture3/Lecture3.md
@@ -11,6 +11,10 @@ drawings:
 transition: slide-left
 mdc: true
 level: 1
+fonts:
+  sans: Noto Sans SC
+  serif: Noto Serif SC
+  mono: JetBrains Mono
 ---
 
 # Lecture 3

--- a/lecture/Lecture4/Lecture4.md
+++ b/lecture/Lecture4/Lecture4.md
@@ -11,6 +11,10 @@ drawings:
 transition: slide-left
 mdc: true
 level: 1
+fonts:
+  sans: Noto Sans SC
+  serif: Noto Serif SC
+  mono: JetBrains Mono
 ---
 
 # Lecture 4

--- a/lecture/Lecture5/Lecture5.md
+++ b/lecture/Lecture5/Lecture5.md
@@ -11,6 +11,10 @@ drawings:
 transition: slide-left
 mdc: true
 level: 1
+fonts:
+  sans: Noto Sans SC
+  serif: Noto Serif SC
+  mono: JetBrains Mono
 ---
 
 # Lecture 5

--- a/lecture/Lecture6/Lecture6.md
+++ b/lecture/Lecture6/Lecture6.md
@@ -11,6 +11,10 @@ drawings:
 transition: slide-left
 mdc: true
 level: 1
+fonts:
+  sans: Noto Sans SC
+  serif: Noto Serif SC
+  mono: JetBrains Mono
 ---
 
 # Lecture 6

--- a/lecture/Lecture7/Lecture7-presentation.md
+++ b/lecture/Lecture7/Lecture7-presentation.md
@@ -11,6 +11,10 @@ drawings:
 transition: slide-left
 mdc: true
 level: 1
+fonts:
+  sans: Noto Sans SC
+  serif: Noto Serif SC
+  mono: JetBrains Mono
 ---
 
 # Lecture 7

--- a/lecture/Lecture7/Lecture7.md
+++ b/lecture/Lecture7/Lecture7.md
@@ -11,6 +11,10 @@ drawings:
 transition: slide-left
 mdc: true
 level: 1
+fonts:
+  sans: Noto Sans SC
+  serif: Noto Serif SC
+  mono: JetBrains Mono
 ---
 
 # Lecture 7

--- a/lecture/Lecture8/Lecture8.md
+++ b/lecture/Lecture8/Lecture8.md
@@ -12,6 +12,10 @@ transition: slide-left
 class: text-center
 mdc: true
 level: 1
+fonts:
+  sans: Noto Sans SC
+  serif: Noto Serif SC
+  mono: JetBrains Mono
 ---
 
 # Lecture 8

--- a/lecture/Lecture9/Lecture9.md
+++ b/lecture/Lecture9/Lecture9.md
@@ -12,6 +12,10 @@ transition: slide-left
 class: text-center
 mdc: true
 level: 1
+fonts:
+  sans: Noto Sans SC
+  serif: Noto Serif SC
+  mono: JetBrains Mono
 ---
 
 # Lecture 9


### PR DESCRIPTION
## Changelog:
- At slidev front formatter part, manually set fonts to simplified Chinese

  ```
  ---
  fonts:
    sans: Noto Sans SC
    serif: Noto Serif SC
    mono: JetBrains Mono
  ---
  ```

## Effect:
Original Japanese Hans:
![image](https://github.com/user-attachments/assets/3af97ca8-3120-4459-b9de-b11dc6c9e1d7)

Current Chinese Hans:
![image](https://github.com/user-attachments/assets/d3f3aed4-879b-4205-9b23-4c25e0bd170b)

Much more convenient to read.
